### PR TITLE
Add installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,62 @@
-# Here are your Instructions
+# Sition Project Setup
+
+This repository contains a FastAPI backend and a React frontend. Follow the steps below to install the required dependencies and run both services locally.
+
+## Requirements
+
+- **Python** 3.10 or higher
+- **Node.js** 20 or higher
+- **MongoDB** running locally or accessible remotely
+
+## Backend
+
+1. Enter the backend directory:
+
+   ```bash
+   cd backend
+   ```
+
+2. Create and activate a virtual environment and install the dependencies:
+
+   ```bash
+   python3 -m venv venv
+   source venv/bin/activate
+   pip install -r requirements.txt
+   ```
+
+3. Configure the environment variables. Create a `.env` file in the `backend` folder with at least the following keys:
+
+   ```env
+   MONGO_URL="mongodb://localhost:27017"
+   DB_NAME="sition"
+   ```
+
+   Adjust the values to match your MongoDB setup.
+
+4. Start the FastAPI server:
+
+   ```bash
+   uvicorn server:app --reload
+   ```
+
+   The API will be available at `http://localhost:8000` by default.
+
+## Frontend
+
+1. From the project root, install the frontend dependencies (requires Node ≥ 20):
+
+   ```bash
+   cd frontend
+   yarn install
+   ```
+
+2. Edit the `frontend/.env` file so that `REACT_APP_BACKEND_URL` points to the backend URL (e.g. `http://localhost:8000`).
+
+3. Start the development server:
+
+   ```bash
+   yarn start
+   ```
+
+   The application will be available at `http://localhost:3000`.
+

--- a/test_result.md
+++ b/test_result.md
@@ -100,4 +100,42 @@
 
 #====================================================================================================
 # Testing Data - Main Agent and testing sub agent both should log testing data below this section
-#====================================================================================================
+#====================================================================================================## user_problem_statement: Añadir al README instrucciones detalladas para instalar dependencias del backend y frontend, requisitos de Python, Node ≥ 20 y MongoDB, cómo configurar las variables de entorno y cómo ejecutar ambos servicios.
+## backend:
+##   - task: "Documentación de instalación y ejecución del backend"
+##     implemented: true
+##     working: true
+##     file: "README.md"
+##     stuck_count: 0
+##     priority: "high"
+##     needs_retesting: false
+##     status_history:
+##         -working: true
+##         -agent: "main"
+##         -comment: "Se añadieron instrucciones de instalación y ejecución del backend."
+## frontend:
+##   - task: "Documentación de instalación y ejecución del frontend"
+##     implemented: true
+##     working: true
+##     file: "README.md"
+##     stuck_count: 0
+##     priority: "high"
+##     needs_retesting: false
+##     status_history:
+##         -working: true
+##         -agent: "main"
+##         -comment: "Se añadieron instrucciones de instalación y ejecución del frontend."
+## metadata:
+##   created_by: "main_agent"
+##   version: "1.0"
+##   test_sequence: 0
+##   run_ui: false
+## test_plan:
+##   current_focus:
+##     - "Documentación de instalación y ejecución"
+##   stuck_tasks:
+##   test_all: false
+##   test_priority: "high_first"
+## agent_communication:
+##   -agent: "main"
+##   -message: "Instrucciones de instalación añadidas al README; no se necesitan pruebas."


### PR DESCRIPTION
## Summary
- expand README with requirements for Python 3.10+, Node 20+, and MongoDB
- add steps to install backend and frontend dependencies
- document environment variables and how to run both servers
- update `test_result.md` with task tracking information

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686c2b70677483299f3deaa4d0b13ec5